### PR TITLE
Fix4413 menu overlap change threshold to 1127px

### DIFF
--- a/molgenis-core-ui/src/main/resources/css/molgenis.css
+++ b/molgenis-core-ui/src/main/resources/css/molgenis.css
@@ -177,7 +177,7 @@ body {
 }
 
 /* Change threshold for collapsing the menu, default is 768px*/
-@media (max-width: 768px) {
+@media (max-width: 1127px) {
     .navbar-toggle {
         display: block;
     }


### PR DESCRIPTION
Changes threshold for collapsing the menu from 768px to 1127px
